### PR TITLE
Make scrape_type use its path parameter

### DIFF
--- a/armour.py
+++ b/armour.py
@@ -9,7 +9,7 @@ else:
 
 
 def scrape_armour(path):
-    conn = common.open_db(db_path)
+    conn = common.open_db(path)
     db = conn.cursor()
     domain = "https://aonprd.com/"
 

--- a/template.py
+++ b/template.py
@@ -7,7 +7,7 @@ else:
     db_path = sys.argv[1]
 
 def scrape_type(path):
-    conn = common.open_db(db_path)
+    conn = common.open_db(path)
 
 if __name__ == "__main__":
     scrape_type(db_path)

--- a/traits.py
+++ b/traits.py
@@ -9,7 +9,7 @@ else:
     db_path = sys.argv[1]
 
 def scrape_type(path):
-    conn = common.open_db(db_path)
+    conn = common.open_db(path)
     db = conn.cursor()
     domain = "https://aonprd.com/"
 


### PR DESCRIPTION
Previously, it used the global db_path which made its parameter redundant.